### PR TITLE
implmented a guild dm restriction using guildID

### DIFF
--- a/welcomeCog/welcome.py
+++ b/welcomeCog/welcome.py
@@ -7,6 +7,8 @@ from redbot.core import Config, checks, commands
 from redbot.core.utils.chat_formatting import box, humanize_list, pagify
 
 url = 'https://raw.githubusercontent.com/Kanium/KanuimCogs/master/welcomeCog/data/embedded_message.json'
+                  
+allowed_guilds = {274657393936302080, 693796372092289024}
 
 async def fetchMessage():
     async def fetch():
@@ -43,6 +45,8 @@ class WelcomeCog(commands.Cog):
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member):
         try:
+            if member.guild.id not in allowed_guilds:
+                return
             if self.message == '':
                 self.message = await fetchMessage()
             message = formatMessage(self.message)


### PR DESCRIPTION
Currently we restrict the bot from sending our welcome dm to the guilds in the set allowed_guilds